### PR TITLE
Add term 9

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -13,30 +13,29 @@ en_2015 = EveryPolitician::Wikidata.wikipedia_xpath(
   url: 'https://en.wikipedia.org/wiki/List_of_members_of_Croatian_Parliament,_2015%E2%80%93',
   after: '//span[@id="MPs_by_party"]',
   xpath: '//table[.//th[.="Name"]]//td[position() = last() - 1]//a[not(@class="new")]/@title',
-) 
+)
 
-en_2011 = EveryPolitician::Wikidata.wikipedia_xpath( 
+en_2011 = EveryPolitician::Wikidata.wikipedia_xpath(
   url: 'https://en.wikipedia.org/wiki/List_of_members_of_Croatian_Parliament,_2011%E2%80%9315',
   after: '//span[@id="MPs_by_party"]',
   xpath: '//table[.//th[.="Name"]]//td[position() = last() - 1]//a[not(@class="new")]/@title',
-) 
+)
 
-sh = EveryPolitician::Wikidata.wikipedia_xpath( 
+sh = EveryPolitician::Wikidata.wikipedia_xpath(
   url: 'https://sh.wikipedia.org/wiki/Sedmi_saziv_Hrvatskog_sabora',
   after: '//span[@id="Spisak_poslanika_po_strankama"]',
   xpath: '//table[.//th[.="Poslanik"]]//td[position() = last() - 1]//a[not(@class="new")]/@title',
-) 
+)
 
-sr = EveryPolitician::Wikidata.wikipedia_xpath( 
+sr = EveryPolitician::Wikidata.wikipedia_xpath(
   url: 'https://sr.wikipedia.org/wiki/Седми_сазив_Хрватског_сабора',
   after: '//span[.="Списак посланика по странкама"]',
   xpath: '//table[.//th[.="Посланик"]]//td[position() = last() - 1]//a[not(@class="new")]/@title',
-) 
+)
 
-EveryPolitician::Wikidata.scrape_wikidata(names: { 
+EveryPolitician::Wikidata.scrape_wikidata(names: {
   hr: [],
   en: en_2011 | en_2015 | en_2016,
   sh: sh,
   sr: sr
 }, output: false)
-

--- a/scraper.rb
+++ b/scraper.rb
@@ -3,7 +3,13 @@
 
 require 'wikidata/fetcher'
 
-en_2015 = EveryPolitician::Wikidata.wikipedia_xpath( 
+en_2016 = EveryPolitician::Wikidata.wikipedia_xpath(
+  url: 'https://en.wikipedia.org/wiki/List_of_members_of_Croatian_Parliament,_2016%E2%80%93',
+  after: '//span[@id="MPs_by_party"]',
+  xpath: '//table[.//th[.="Name"]]//td[position() = last() - 1]//a[not(@class="new")]/@title',
+)
+
+en_2015 = EveryPolitician::Wikidata.wikipedia_xpath(
   url: 'https://en.wikipedia.org/wiki/List_of_members_of_Croatian_Parliament,_2015%E2%80%93',
   after: '//span[@id="MPs_by_party"]',
   xpath: '//table[.//th[.="Name"]]//td[position() = last() - 1]//a[not(@class="new")]/@title',
@@ -29,7 +35,7 @@ sr = EveryPolitician::Wikidata.wikipedia_xpath(
 
 EveryPolitician::Wikidata.scrape_wikidata(names: { 
   hr: [],
-  en: en_2011 | en_2015,
+  en: en_2011 | en_2015 | en_2016,
   sh: sh,
   sr: sr
 }, output: false)


### PR DESCRIPTION
There has been elections in 2016 and there is a new wikipedia page
listing the members of the parliament for term 9. This PR adds changes 
to scrape that page.

* [x] scraper is on Morph.io under the "everypolitician-scrapers" group? https://morph.io/everypolitician-scrapers/croatian-parliament-wikidata
* [x] scraper's GitHub "Website" link points at morph.io page? https://github.com/everypolitician-scrapers/croatian-parliament-wikidata
* [x] scraper is set to auto-run? https://morph.io/everypolitician-scrapers/croatian-parliament-wikidata/settings
* [x] scraper has webhook set? _(usually only set on Wikidata person-data scrapers)_ https://morph.io/everypolitician-scrapers/croatian-parliament-wikidata/settings
* [x] scraper is configured for archiving? _(unless source doesn't require that)_ Not needed because Wikidata.
